### PR TITLE
Fixes hard-coded path in spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.1.*
 
+### Current
+Bug fix - remove hard coded path in spec expectation
+
 ### 0.1.8
 Bug fix - preboot commands were using drudgeon's API incorrectly.
 

--- a/spec/fsm.spec.js
+++ b/spec/fsm.spec.js
@@ -124,8 +124,10 @@ describe.only( "FSM", function() {
 						server.raise( "noConnection" );
 					} );
 
+					var expectedPath = path.resolve( __dirname, "../installs/test-me-master" );
+
 					fsMock.expects( "exists" )
-						.withArgs( "/git/labs/nonstop/nonstop/installs/test-me-master" )
+						.withArgs( expectedPath )
 						.returns( false );
 
 					fsm = fsmFn( config, server, pack, processhost, {}, bootFile, fs );


### PR DESCRIPTION
When I checked the last PR, I noticed some specs would only run if run from a directory matching `/git/labs/nonstop/nonstop` - this fix makes it dynamic based on the location of the project/spec file.
